### PR TITLE
Fix: Install dependencies in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
 
     # services:
-    #  redis:
-    #    image: redis
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    #   redis:
+    #     image: redis
+    #     ports:
+    #       - 6379:6379
+    #     options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - name: Install packages
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config google-chrome-stable
@@ -74,6 +74,10 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+
+      # *** ADD THIS STEP ***
+      - name: Install dependencies
+        run: bundle install
 
       - name: Run tests
         env:


### PR DESCRIPTION
This pull request adds an explicit bundle install step to the CI workflow (ci.yml). This ensures that all necessary gems, including database_cleaner, are installed in the GitHub Actions environment before the tests are executed. This should resolve the LoadError: cannot load such file -- database_cleaner/active_record that was causing the workflow to fail.